### PR TITLE
Optimize screenshot capture/compression and robust UDP frame assembly

### DIFF
--- a/Client/ClientForm.cs
+++ b/Client/ClientForm.cs
@@ -786,7 +786,7 @@ namespace testUdpTcp
             // Lấy địa chỉ broadcast của mạng local
             IPAddress broadcastAddress = GetBroadcastAddress();
             int i = 1;
-            int fps = 120;
+            int fps = 20;
             while (isRunningscreenshot)
             {
                 try
@@ -797,16 +797,21 @@ namespace testUdpTcp
                     int screenWidth = SystemInformation.VirtualScreen.Width;
                     int screenHeight = SystemInformation.VirtualScreen.Height;
 
-                    using (Bitmap screenshot = new Bitmap(screenWidth, screenHeight, PixelFormat.Format32bppArgb))
+                    int targetWidth = Math.Min(1280, screenWidth);
+                    int targetHeight = (int)(screenHeight * (targetWidth / (double)screenWidth));
+
+                    using (Bitmap fullScreenshot = new Bitmap(screenWidth, screenHeight, PixelFormat.Format24bppRgb))
+                    using (Graphics fullGraphics = Graphics.FromImage(fullScreenshot))
                     {
+                        fullGraphics.CopyFromScreen(screenLeft, screenTop, 0, 0, fullScreenshot.Size, CopyPixelOperation.SourceCopy);
+                        DrawCursorOnScreenshot(fullGraphics);
+
+                        using (Bitmap screenshot = new Bitmap(targetWidth, targetHeight, PixelFormat.Format24bppRgb))
                         using (Graphics graphics = Graphics.FromImage(screenshot))
                         {
-                            graphics.CopyFromScreen(screenLeft, screenTop, 0, 0, screenshot.Size, CopyPixelOperation.SourceCopy);
+                            graphics.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.Low;
+                            graphics.DrawImage(fullScreenshot, new Rectangle(0, 0, targetWidth, targetHeight));
 
-                            // Draw the cursor
-                            DrawCursorOnScreenshot(graphics);
-
-                            // Compress and send the screenshot
                             using (MemoryStream stream = new MemoryStream())
                             {
                                 CompressAndSendImage(i, screenshot, stream, udpBufferSize, udpClient, broadcastAddress);
@@ -877,11 +882,15 @@ namespace testUdpTcp
                     int screenWidth = SystemInformation.VirtualScreen.Width;
                     int screenHeight = SystemInformation.VirtualScreen.Height;
 
-                    using (Bitmap screenshot = new Bitmap(screenWidth, screenHeight, PixelFormat.Format32bppArgb))
+                    const int targetWidth = 1280;
+                    int targetHeight = (int)(screenHeight * (targetWidth / (double)screenWidth));
+
+                    using (Bitmap screenshot = new Bitmap(targetWidth, targetHeight, PixelFormat.Format24bppRgb))
                     {
                         using (Graphics graphics = Graphics.FromImage(screenshot))
                         {
-                            graphics.CopyFromScreen(screenLeft, screenTop, 0, 0, screenshot.Size, CopyPixelOperation.SourceCopy);
+                            graphics.CopyFromScreen(screenLeft, screenTop, 0, 0, new Size(screenWidth, screenHeight), CopyPixelOperation.SourceCopy);
+                            graphics.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.Low;
                             DrawCursorOnScreenshot(graphics);
                             SendImage(IpServer, 8765, Environment.MachineName, screenshot);
                         }
@@ -903,16 +912,16 @@ namespace testUdpTcp
 
         private void CompressAndSendImage(int i, Bitmap image, MemoryStream stream, int bufferSize, UdpClient udpClient, IPAddress broadcastAddress)
         {
-            long quality = 100L; // Bắt đầu với chất lượng 90%
+            long quality = 60L;
 
             byte[] imageData;
             do
             {
-                stream.SetLength(0); // Đặt lại stream cho mỗi lần nén
+                stream.SetLength(0);
                 SaveJpeg(stream, image, quality);
                 imageData = stream.ToArray();
-                quality -= 10; // Giảm chất lượng đi 10% cho lần tiếp theo nếu cần
-            } while (imageData.Length > bufferSize && quality > 100);
+                quality -= 5;
+            } while (imageData.Length > 60_000 && quality >= 30);
 
             int bytesSent = 0;
             int index = 0;
@@ -925,7 +934,8 @@ namespace testUdpTcp
                 int signalLength = signal.Length;
 
                 int remainingBytes = imageData.Length - bytesSent;
-                int bytesToSend = Math.Min(bufferSize - signalLength - 100, remainingBytes); // Đảm bảo có chỗ cho tín hiệu
+                const int maxDatagramPayload = 1200;
+                int bytesToSend = Math.Min(maxDatagramPayload - signalLength, remainingBytes);
 
                 // Tạo một mảng byte mới để chứa tín hiệu và dữ liệu cần gửi
                 byte[] dataToSend = new byte[signalLength + bytesToSend];

--- a/Client/SlideShowForm.cs
+++ b/Client/SlideShowForm.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -22,6 +23,13 @@ namespace testUdpTcp
         private string serverIP;
         private string protocal;
         private bool isRunning;
+        private class FrameBuffer
+        {
+            public List<byte[]> Parts;
+            public DateTime FirstSeen;
+        }
+
+        private int _latestCompletedFrameId = -1;
 
         public string ServerIP
         {
@@ -114,7 +122,8 @@ namespace testUdpTcp
         }
         private void ListenForUdpClients()
         {
-            Dictionary<int, List<byte[]>> imagesData = new Dictionary<int, List<byte[]>>();
+            Dictionary<int, FrameBuffer> imagesData = new Dictionary<int, FrameBuffer>();
+            TimeSpan frameTimeout = TimeSpan.FromMilliseconds(50);
 
 
             try
@@ -138,23 +147,31 @@ namespace testUdpTcp
                         Array.Copy(receivedData, 13, imageData, 0, imageData.Length);
 
                         // Khởi tạo danh sách các phần của ảnh nếu chưa có
-                        if (!imagesData.ContainsKey(imageIndex))
+                        if (imageIndex < _latestCompletedFrameId)
                         {
-                            imagesData[imageIndex] = new List<byte[]>(new byte[cutCount][]);
+                            continue;
                         }
 
-                        // Lưu phần ảnh vào vị trí tương ứng
-                        imagesData[imageIndex][cutIndex - 1] = imageData;
+                        if (!imagesData.ContainsKey(imageIndex))
+                        {
+                            imagesData[imageIndex] = new FrameBuffer
+                            {
+                                Parts = new List<byte[]>(new byte[cutCount][]),
+                                FirstSeen = DateTime.UtcNow
+                            };
+                        }
+
+                        imagesData[imageIndex].Parts[cutIndex - 1] = imageData;
 
                         // In thông tin kiểm tra
                         Console.WriteLine($"Received part {cutIndex}/{cutCount} of image {imageIndex}");
 
                         // Kiểm tra xem tất cả các phần của ảnh đã được nhận đủ chưa
-                        if (imagesData[imageIndex].All(part => part != null))
+                        if (imagesData[imageIndex].Parts.All(part => part != null))
                         {
                             // Tạo ảnh từ dữ liệu đã ghép và hiển thị ảnh
                             List<byte> completeImageData = new List<byte>();
-                            foreach (var part in imagesData[imageIndex])
+                            foreach (var part in imagesData[imageIndex].Parts)
                             {
                                 completeImageData.AddRange(part);
                             }
@@ -166,9 +183,18 @@ namespace testUdpTcp
                                 UpdatePictureBox(image);
                             }
 
-                            // Xóa dữ liệu của ảnh vừa nhận xong để chuẩn bị cho lần nhận ảnh tiếp theo
+                            _latestCompletedFrameId = imageIndex;
                             imagesData.Remove(imageIndex);
                         }
+                    }
+
+                    var expiredKeys = imagesData
+                        .Where(kvp => DateTime.UtcNow - kvp.Value.FirstSeen > frameTimeout)
+                        .Select(kvp => kvp.Key)
+                        .ToList();
+                    foreach (var key in expiredKeys)
+                    {
+                        imagesData.Remove(key);
                     }
                 }
 


### PR DESCRIPTION
### Motivation
- Reduce network usage and improve streaming stability by lowering capture rate and shrinking image payloads.
- Improve client-side decoding reliability by implementing deterministic frame reassembly and garbage collection of stale parts.
- Lower CPU/encoding overhead by downscaling images before compression and using a smaller pixel format.

### Description
- Lowered continuous capture rate from `120` to `20` FPS and limited capture width to `1280` while preserving aspect ratio and using `PixelFormat.Format24bppRgb` for screenshots.
- Capture full-screen into a temporary bitmap, draw the cursor, then downscale with `InterpolationMode.Low` before compression to reduce quality loss and CPU overhead.
- Adjusted JPEG encoding to start at quality `60` and iteratively reduce by `5` until the compressed image is under ~`60_000` bytes or quality reaches `30`, and changed chunking to use a `maxDatagramPayload` of `1200` bytes when sending UDP datagrams.
- Reworked UDP receiver to use a `FrameBuffer` class with `Parts` and `FirstSeen`, added `_latestCompletedFrameId` to skip stale frames, and purge partial frames older than `50ms` to avoid assembly stalls.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f522dd4c10832395adae1d7b6501fd)